### PR TITLE
PXFileSerializer now outputs the VARIABLECODE keyword in the PX file

### DIFF
--- a/PCAxis.Common/Serializers/PXFileSerializer.vb
+++ b/PCAxis.Common/Serializers/PXFileSerializer.vb
@@ -164,6 +164,13 @@ Namespace PCAxis.Paxiom
                 '*VALUES
                 For j As Integer = 0 To meta.Variables.Count - 1
                     var = meta.Variables(j)
+
+                    'Added by Statistics Denmark - Support for variable codes in PX file - START'
+                    writer.BeginPXLine(PXKeywords.VARIABLE_CODE, GetVariableName(var), lang)
+                    writer.WriteValue(var.Code)
+                    writer.EndPXLine()
+                    'Added by Statistics Denmark - Support for variable codes in PX file - END'
+
                     writer.BeginPXLine(PXKeywords.VALUES, GetVariableName(var), lang)
 
                     For i As Integer = 0 To var.Values.Count - 2
@@ -982,6 +989,13 @@ Namespace PCAxis.Paxiom
             '*VALUES
             For j As Integer = 0 To meta.Variables.Count - 1
                 var = meta.Variables(j)
+
+................'Added by Statistics Denmark - Support for variable codes in PX file - START'
+................writer.BeginPXLine(PXKeywords.VARIABLE_CODE, GetVariableName(var), lang)
+................writer.WriteValue(var.Code)
+................writer.EndPXLine()
+................'Added by Statistics Denmark - Support for variable codes in PX file - END'
+
                 writer.BeginPXLine(PXKeywords.VALUES, GetVariableName(var), lang)
 
                 For i As Integer = 0 To var.Values.Count - 2


### PR DESCRIPTION
The current version of the PXFileSerializer does not output the keyword VARIABLECODE that maps the variable name to the variable code. The suggested change does this.

A usecase for the keyword VARIABLECODE is that a user only has the PX file, but needs the variable code to fetch data, and the variable name cannot be used. 

Such a scenario is found in a new project from Statistics Denmark that utilizes the PX components through the StatBank-API. So the StatBank-API needs to be able to output the VARIABLECODE keyword - hence the suggested change. Also, this change is also requested by employees at Statistics Denmark for other usecases in relation to production of statistical data.

An example: A variable name could be "country of origin", but the code might be entirely different, e.g. CTRYORI. In the current version there is no way to obtain this code (CTRYORI or likewise) from the PX file, and no way to map it from one to the other.

The suggested code outputs one line for each variable with a mapping from the variable name to its code - in the before mentioned case this would be:

VARIABLECODE("country of origin")="CTRYORI"

Also, feel free to review the code and implement it another way if more suited. For example, consider adding a constructor overload to PXFileSerializer (or a setting of sorts) with a boolean parameter (defaulting to false - or true, if you like) to determine whether VARIABLECODE should be outputted. This way, nothing will break - but nothing should break anyway since VARIABLECODE is an optional keyword.